### PR TITLE
Move shared code approach over to chrome version

### DIFF
--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -78,7 +78,8 @@
         <br>
         <div id="spotify" class="id-field-wrapper">
             <span class="note">
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Will prompt you to select playlist from Spotify.
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Will prompt you to select playlist from Spotify.<br />
+                <span style="color: red;">Note: To use this setting, you must be logged into Spotify on this browser prior to initiating extension.</span>
             </span>
         </div>
 

--- a/chrome/scripts/popup.js
+++ b/chrome/scripts/popup.js
@@ -32,7 +32,7 @@ chrome.storage.sync.get([
     optionsForm.otherLiveURL.value = result.otherLiveURL ?? 'https://tv.youtube.com/watch/_2ONrjDR7S8';
     optionsForm.overlayVideoLocationHorizontal.value = result.overlayVideoLocationHorizontal ?? 'middle';
     optionsForm.overlayVideoLocationVertical.value = result.overlayVideoLocationVertical ?? 'middle';
-    optionsForm.mainVideoFade.value = result.mainVideoFade ?? 55;
+    optionsForm.mainVideoFade.value = result.mainVideoFade ?? 65;
     optionsForm.videoOverlayWidth.value = result.videoOverlayWidth ?? 75;
     optionsForm.videoOverlayHeight.value = result.videoOverlayHeight ?? 75;
     optionsForm.mainVideoVolumeDuringCommercials.value = result.mainVideoVolumeDuringCommercials ?? 0;
@@ -56,7 +56,7 @@ chrome.storage.sync.get([
     for (let i = 0, max = videoTypeRadios.length; i < max; i++) {
         videoTypeRadios[i].addEventListener('change', toggleIDFieldVisability);
     }
-    
+
 });
 
 
@@ -169,8 +169,4 @@ function toggleModeInstructionsVisability() {
         modeInstructions[i].style.display = 'none';
     }
     document.getElementById(optionsForm.commercialDetectionMode.value).style.display = 'block';
-}
-
-document.getElementById("overlayVideoType-spotify").onclick = function () {
-    alert(`Note: To use this setting, you must be logged into Spotify on this browser prior to initiating extension.`);
 }

--- a/chrome/scripts/spotify.js
+++ b/chrome/scripts/spotify.js
@@ -30,7 +30,7 @@ function pause() {
         }
 
     } //TODO: add else here to close spotify and then show an error on the main tab saying there was and issue and to refresh
-    
+
 }
 
 
@@ -159,6 +159,12 @@ function initialSetup() {
 
                         chrome.runtime.sendMessage({ action: "glimpse_main_tab" });
                         banner.innerText = 'Tab opened for use of the YTOC extension. Do not close until you are done using YTOC extension.';
+
+                        setTimeout(() => {
+
+                            pause();
+
+                        }, 500);
 
                     }, 500);
 

--- a/firefox/scripts/background.js
+++ b/firefox/scripts/background.js
@@ -355,6 +355,15 @@ function startCommercialState(overlayVideoType, overlayHostName) {
 
                 }
 
+            } else if (overlayHostName == 'tv.youtube.com') {
+
+                if (document.querySelector('[aria-label="Play (k)"]')) {
+
+                    document.querySelector('[aria-label="Play (k)"]').click();
+
+                }
+
+
             } else {
 
                 if (document.getElementsByTagName('video')[0].paused) {
@@ -410,6 +419,15 @@ function stopCommercialState(overlayVideoType, overlayHostName) {
                     document.getElementsByTagName('video')[0].muted = true;
 
                 }
+
+            } else if (overlayHostName == 'tv.youtube.com') {
+
+                if (document.querySelector('[aria-label="Pause (k)"]')) {
+
+                    document.querySelector('[aria-label="Pause (k)"]').click();
+
+                }
+                
 
             } else {
 

--- a/firefox/scripts/background.js
+++ b/firefox/scripts/background.js
@@ -204,8 +204,9 @@ function initialCommercialState(shouldHideYTBackground, overlayHostName) {
 
     //making sure if requested overlay video isn't a yt video and has same domain as main/background video that script wasn't loaded into that main video frame
     if (overlayHostName != 'www.youtube.com') {
-        if (typeof mainVideo !== 'undefined') {
-            if (mainVideo == document.getElementsByTagName('video')[0]) {
+        if (typeof mainVideoCollection !== 'undefined') {
+            //TODO: is this second check necessary if we already know mainVideoCollection is defined? would the frames share this variable?
+            if (mainVideoCollection == document.getElementsByTagName('video')) {
                 return;
             }
         }
@@ -320,8 +321,8 @@ function startCommercialState(overlayVideoType, overlayHostName) {
 
     //making sure if requested overlay video isn't a yt video and has same domain as main/background video that script wasn't loaded into that main video frame
     if (overlayHostName != 'www.youtube.com') {
-        if (typeof mainVideo !== 'undefined') {
-            if (mainVideo == document.getElementsByTagName('video')[0]) {
+        if (typeof mainVideoCollection !== 'undefined') {
+            if (mainVideoCollection == document.getElementsByTagName('video')) {
                 return;
             }
         }
@@ -355,22 +356,13 @@ function startCommercialState(overlayVideoType, overlayHostName) {
 
                 }
 
-            } else if (overlayHostName == 'tv.youtube.com') {
+            } else if (overlayHostName == 'tv.youtube.com' && document.querySelector('[aria-label="Play (k)"]')) {
 
-                if (document.querySelector('[aria-label="Play (k)"]')) {
+                document.querySelector('[aria-label="Play (k)"]').click();
 
-                    document.querySelector('[aria-label="Play (k)"]').click();
+            } else if (document.getElementsByTagName('video')[0].paused) {
 
-                }
-
-
-            } else {
-
-                if (document.getElementsByTagName('video')[0].paused) {
-
-                    document.getElementsByTagName('video')[0].play();
-
-                }
+                document.getElementsByTagName('video')[0].play();
 
             }
 
@@ -385,8 +377,8 @@ function stopCommercialState(overlayVideoType, overlayHostName) {
 
     //making sure if requested overlay video isn't a yt video and has same domain as main/background video that script wasn't loaded into that main video frame
     if (overlayHostName != 'www.youtube.com') {
-        if (typeof mainVideo !== 'undefined') {
-            if (mainVideo == document.getElementsByTagName('video')[0]) {
+        if (typeof mainVideoCollection !== 'undefined') {
+            if (mainVideoCollection == document.getElementsByTagName('video')) {
                 return;
             }
         }
@@ -420,22 +412,13 @@ function stopCommercialState(overlayVideoType, overlayHostName) {
 
                 }
 
-            } else if (overlayHostName == 'tv.youtube.com') {
+            } else if (overlayHostName == 'tv.youtube.com' && document.querySelector('[aria-label="Pause (k)"]')) {
 
-                if (document.querySelector('[aria-label="Pause (k)"]')) {
-
-                    document.querySelector('[aria-label="Pause (k)"]').click();
-
-                }
+                document.querySelector('[aria-label="Pause (k)"]').click();
                 
+            } else if (!document.getElementsByTagName('video')[0].paused) {
 
-            } else {
-
-                if (!document.getElementsByTagName('video')[0].paused) {
-
-                    document.getElementsByTagName('video')[0].pause();
-
-                }
+                document.getElementsByTagName('video')[0].pause();
 
             }
 

--- a/firefox/scripts/content.js
+++ b/firefox/scripts/content.js
@@ -3,7 +3,7 @@ var isFirefox = true; //********************
 
 var isCommercialState = false;
 var firstClick = true;
-var mainVideo;
+var mainVideoCollection;
 var isFirstRun = true;
 var fullScreenAlertSet = false;
 var overlayScreen;
@@ -188,23 +188,9 @@ function initialRun() {
 
     }
 
-    mainVideo = document.getElementsByTagName('video')[0]; //TODO: grab all videos on page and loop and interaction with all of them
+    mainVideoCollection = document.getElementsByTagName('video'); //TODO: grab all videos on page and loop and interaction with all of them
 
-    //muting main/background video
-    if (mainVideoVolumeDuringCommercials == 0) {
-
-        //using the actually controls to mute YTTV because for whatever reason, it will unmute itself
-        if (window.location.hostname == 'tv.youtube.com' && document.querySelector('[aria-label="Mute (m)"]')) {
-            document.querySelector('[aria-label="Mute (m)"]').click();
-        }
-
-        mainVideo.muted = true;
-
-    } else if (mainVideoVolumeDuringCommercials < 1) {
-
-        mainVideo.volume = mainVideoVolumeDuringCommercials;
-
-    } //else do nothing for 100
+    muteMainVideo();
 
     //TODO: create a new variable for music/video boolean or whatever
     if (overlayVideoType == 'spotify' || overlayVideoType == 'other-tabs') {
@@ -222,6 +208,58 @@ function initialRun() {
             chrome.runtime.sendMessage({ action: "initial_execute_overlay_video_interaction" });
         }, 2000);
     }
+
+}
+
+
+function muteMainVideo() {
+
+    //muting main/background video
+    if (mainVideoVolumeDuringCommercials == 0) {
+
+        //using the actual controls to mute YTTV because for whatever reason, it will unmute itself
+        if (window.location.hostname == 'tv.youtube.com' && document.querySelector('[aria-label="Mute (m)"]')) {
+
+            document.querySelector('[aria-label="Mute (m)"]').click();
+
+        }
+
+        for (let i = 0; i < mainVideoCollection.length; i++) {
+            mainVideoCollection[i].muted = true; // Mute each video
+        }
+
+    } else if (mainVideoVolumeDuringCommercials < 1) {
+
+        for (let i = 0; i < mainVideoCollection.length; i++) {
+            mainVideoCollection[i].volume = mainVideoVolumeDuringCommercials;
+        }
+
+    } //else do nothing for 100
+
+}
+
+
+function unmuteMainVideo() {
+
+    if (mainVideoVolumeDuringCommercials == 0) {
+
+        if (window.location.hostname == 'tv.youtube.com' && document.querySelector('[aria-label="Unmute (m)"]')) {
+
+            document.querySelector('[aria-label="Unmute (m)"]').click();
+
+        }
+
+        for (let i = 0; i < mainVideoCollection.length; i++) {
+            mainVideoCollection[i].muted = false; // Mute each video
+        }
+
+    } else if (mainVideoVolumeDuringCommercials < 1) {
+
+        for (let i = 0; i < mainVideoCollection.length; i++) {
+            mainVideoCollection[i].volume = mainVideoVolumeDuringNonCommercials;
+        }
+
+    } //else do nothing for 100
 
 }
 
@@ -251,14 +289,7 @@ function endCommercialMode() {
 
     }
 
-    if (mainVideoVolumeDuringCommercials == 0) {
-        if (window.location.hostname == 'tv.youtube.com' && document.querySelector('[aria-label="Unmute (m)"]')) {
-            document.querySelector('[aria-label="Unmute (m)"]').click();
-        }
-        mainVideo.muted = false;
-    } else if (mainVideoVolumeDuringCommercials < 1) {
-        mainVideo.volume = mainVideoVolumeDuringNonCommercials;
-    } //else do nothing for 100
+    unmuteMainVideo();
 
 }
 
@@ -306,14 +337,7 @@ function startCommercialMode() {
 
         }
 
-        if (mainVideoVolumeDuringCommercials == 0) {
-            if (window.location.hostname == 'tv.youtube.com' && document.querySelector('[aria-label="Mute (m)"]')) {
-                document.querySelector('[aria-label="Mute (m)"]').click();
-            }
-            mainVideo.muted = true;
-        } else if (mainVideoVolumeDuringCommercials < 1) {
-            mainVideo.volume = mainVideoVolumeDuringCommercials;
-        } //else do nothing for 100
+        muteMainVideo();
 
     }
 
@@ -371,7 +395,7 @@ chrome.runtime.onMessage.addListener(function (message) {
                             ytLiveID = result.ytLiveID ?? 'QhJcIlE0NAQ';
                             otherVideoURL = result.otherVideoURL ?? 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4';
                             otherLiveURL = result.otherLiveURL ?? 'https://tv.youtube.com/watch/_2ONrjDR7S8';
-                            mainVideoFade = result.mainVideoFade ?? 55;
+                            mainVideoFade = result.mainVideoFade ?? 65;
                             if (overlayVideoType != 'spotify' && overlayVideoType != 'other-tabs') {
                                 overlayVideoLocationHorizontal = result.overlayVideoLocationHorizontal ?? 'middle';
                                 overlayVideoLocationVertical = result.overlayVideoLocationVertical ?? 'middle';
@@ -927,7 +951,7 @@ function startViewingTab(windowDimensions) {
 
     if (!isFirefox) {
 
-        chrome.runtime.sendMessage({ action: "view-tab", windowDimensions: windowDimensions });
+        chrome.runtime.sendMessage({ action: "chrome-view-tab", windowDimensions: windowDimensions });
         window.addEventListener('beforeunload', stopViewingTab);
 
     }

--- a/firefox/scripts/popup.js
+++ b/firefox/scripts/popup.js
@@ -32,7 +32,7 @@ chrome.storage.sync.get([
     optionsForm.otherLiveURL.value = result.otherLiveURL ?? 'https://tv.youtube.com/watch/_2ONrjDR7S8';
     optionsForm.overlayVideoLocationHorizontal.value = result.overlayVideoLocationHorizontal ?? 'middle';
     optionsForm.overlayVideoLocationVertical.value = result.overlayVideoLocationVertical ?? 'middle';
-    optionsForm.mainVideoFade.value = result.mainVideoFade ?? 55;
+    optionsForm.mainVideoFade.value = result.mainVideoFade ?? 65;
     optionsForm.videoOverlayWidth.value = result.videoOverlayWidth ?? 75;
     optionsForm.videoOverlayHeight.value = result.videoOverlayHeight ?? 75;
     optionsForm.mainVideoVolumeDuringCommercials.value = result.mainVideoVolumeDuringCommercials ?? 0;

--- a/firefox/scripts/spotify.js
+++ b/firefox/scripts/spotify.js
@@ -160,6 +160,12 @@ function initialSetup() {
                         chrome.runtime.sendMessage({ action: "glimpse_main_tab" });
                         banner.innerText = 'Tab opened for use of the YTOC extension. Do not close until you are done using YTOC extension.';
 
+                        setTimeout(() => {
+
+                            pause();
+
+                        }, 500);
+
                     }, 500);
 
                 });

--- a/firefox/styles/style.css
+++ b/firefox/styles/style.css
@@ -23,8 +23,8 @@
     border-radius: 50% !important;
     z-index: 2147483646 !important;
     position: absolute !important;
-    width: 10px !important;
-    height: 10px !important;
+    width: 6px !important;
+    height: 6px !important;
     pointer-events: none !important;
 }
 
@@ -77,8 +77,8 @@
     z-index: 2147483646 !important;
     position: absolute !important;
     display: inline-block !important;
-    width: 10px !important;
-    height: 10px !important;
+    width: 6px !important;
+    height: 6px !important;
     border-radius: 50% !important;
     /*border-style: solid !important;
     border-width: 2px !important;


### PR DESCRIPTION
1. Previous update that was made to firefox version so that firefox version and chrome version could share the same exact code except with a single variable difference in content.js was migrated over to chrome version.
2. Made it so YTTV videos could be used for non-live overlay videos.
3. Fixed issue Amazon was having where it would mute/unmute phantom video (updated it to mute/unmute all videos on page - could potentially run into issue with doing this on certain sites in the future).
4. Made it so Spotify mutes directed after user choses a playlist so main video and Spotify don't play at the same time before user sets video back to full screen.