### PR TITLE
Add reverse mode to firefox

### DIFF
--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -234,11 +234,11 @@
             <br />
             <br />
 
-            <b>Color Mismatch Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to not match its original color at time of selection before declaring a commercial has begun and playing the video overtop of the commercial.</span></span>
+            <b>Color Mismatch Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to not match its original color at time of selection before declaring a commercial has begun and playing the video overtop of the commercial. NOTE: While in Reverse Pixel Detection Mode, this value is used count matches before declaring commercial break.</span></span>
             <input type="number" name="mismatchCountThreshold" id="mismatchCountThreshold" min="1"><br>
             <br>
 
-            <b>Color Match Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to match its original color at time of selection before declaring the program as resumed and hiding the overlaid video.</span></span>
+            <b>Color Match Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to match its original color at time of selection before declaring the program as resumed and hiding the overlaid video. NOTE: While in Reverse Pixel Detection Mode, this value is used count mismatches before declaring being out of commercial break.</span></span>
             <input type="number" name="matchCountThreshold" id="matchCountThreshold" min="1"><br>
             <br>
 

--- a/chrome/scripts/content.js
+++ b/chrome/scripts/content.js
@@ -454,7 +454,7 @@ chrome.runtime.onMessage.addListener(function (message) {
                             mismatchCountThreshold = result.mismatchCountThreshold ?? 8;
                             matchCountThreshold = result.matchCountThreshold ?? 2;
                             colorDifferenceMatchingThreshold = result.colorDifferenceMatchingThreshold ?? 12;
-                            manualOverrideCooldown = result.manualOverrideCooldown ?? 30;
+                            manualOverrideCooldown = result.manualOverrideCooldown ?? 55;
                             isDebugMode = result.isDebugMode ?? false;
                             isPiPMode = result.isPiPMode ?? true;
                             pipLocationHorizontal = result.pipLocationHorizontal ?? 'top';
@@ -800,7 +800,7 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
             }
 
             if ((!isOppositePixelDetectionMode && !match) || (isOppositePixelDetectionMode && match)) {
-                //color mismatch
+                //color indicating potential commercial break
 
                 mismatchCount++;
                 matchCount = 0;
@@ -860,7 +860,7 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
                 }
 
             } else {
-                //color match
+                //color indicating potentially out of commercial break
 
                 matchCount++;
                 mismatchCount = 0;
@@ -1170,6 +1170,11 @@ function indicateSelectedPixel(selectedPixel) {
     let selectedPixelRing = document.createElement('div');
 
     selectedPixelRing.className = "ytoc-selection-indicator";
+    if (isFirefox) {
+        //firefox does not need as large of a hole
+        selectedPixelRing.style.setProperty("width", "6px", "important");
+        selectedPixelRing.style.setProperty("height", "6px", "important");
+    }
     //setting location of hole for the pixel color detector to look through, subtracting by 3 for radius of hole
     selectedPixelRing.style.left = (selectedPixel.x - 3) + 'px';
     selectedPixelRing.style.top = (selectedPixel.y - 3) + 'px';

--- a/chrome/scripts/popup.js
+++ b/chrome/scripts/popup.js
@@ -54,7 +54,7 @@ chrome.storage.sync.get([
     optionsForm.mismatchCountThreshold.value = result.mismatchCountThreshold ?? 8;
     optionsForm.matchCountThreshold.value = result.matchCountThreshold ?? 2;
     optionsForm.colorDifferenceMatchingThreshold.value = result.colorDifferenceMatchingThreshold ?? 12;
-    optionsForm.manualOverrideCooldown.value = result.manualOverrideCooldown ?? 30;
+    optionsForm.manualOverrideCooldown.value = result.manualOverrideCooldown ?? 55;
     optionsForm.isDebugMode.checked = result.isDebugMode ?? false;
     optionsForm.isPiPMode.checked = result.isPiPMode ?? true;
     optionsForm.pipLocationHorizontal.value = result.pipLocationHorizontal ?? 'left';

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -5,9 +5,8 @@
   "icons": {
     "128": "icon128.png"
   },
-  "version": "1.5",
+  "version": "1.6",
   "permissions": [
-    "tabs",
     "activeTab",
     "scripting",
     "storage",

--- a/firefox/pixel-select-instructions.html
+++ b/firefox/pixel-select-instructions.html
@@ -14,111 +14,155 @@
             width: auto !important;
             color: white;
         }
+
     </style>
 </head>
 <body>
     <br />
     <h1><span style="color: red; position: relative; z-index: 100;">YouTube&trade;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br /><span style="color: rgb(140, 179, 210, .9);">Over Commercials</span></h1>
     <br />
-    <h2>Auto Commercial Detection Mode</h2>
-    <p>
-        This mode works by the user (you) selecting a specific pixel on a logo/graphic that only displays when your live game/sport/event/race/program/show is on. Then, the extension continuously checks to
-        see if the pixel selected remains the same color when the logo/graphic is displayed. When the color changes, we know this is most likely due to a commercial because the logo/graphic went away and since
-        commercials are boring, the extension starts playing your YouTube video over top of the commercial. When the logo/graphic color comes back, we know your live program/show/sport/event is most likely back on,
-        so the extension pauses/hides your YouTube video.
-    </p>
-    <h3 style="color: red;">Quick Start Instructions:</h3>
-    <ol>
-        <li>
-            Make sure your live game/program is on (out of commercial).
-            <ol type="i">
-                <li>
-                    If this isn't going to be anytime soon, refresh the page and hit the extension keyboard shortcut when it is back.
-                </li>
-            </ol>
-        </li>
-        <li>
-            Click on a pixel outside this box that is within a non-transparent logo or graphic on your game/program (see tips/tricks below for more details).
-            <ol type="i">
-                <li>
-                    You might need to wait for any video player UI to go away.
-                </li>
-                <li>
-                    Refresh the page and then hit the extension keyboard shortcut again if you ever want to chose a different pixel location.
-                </li>
-            </ol>
-        </li>
-        <li>
-            Let the extension automatically detect the commercials and display your YouTube videos over top of them.
-            <ol type="i">
-                <li>
-                    You can also manually display/hide your YouTube video, temporarily disabling the auto-detection, at any point by hitting the extension keyboard shortcut.
-                </li>
-            </ol>
-        </li>
-    </ol>
-    <h3>Tips/Tricks:</h3>
-    <ul>
-        <li>
-            <b>Selecting a Pixel</b>: Automatically detecting commercials across all games/sports/leagues/shows/networks across all streaming platforms isn't an exact science.
-            What will make your experience the best is selecting the best pixel to monitor that you can.
-            <ul>
-                <li>
-                    You'll want to prioritize selecting a pixel within the channel logo (e.g. the NBC logo) if it is not semi-transparent.
-                    <ul>
-                        <li>
-                            Within the channel logo, you'll want to try to select a color that isn't completely white or completely black (e.g. the blue inside the NBC logo). You'll want to aim for as center mass of the color as possible.
-                            <ul>
-                                <li>
-                                    If the logo is only black or white, these will do, just prioritize white then black, the only issue you may run into with these are if a commercial has a lot of white or black in them, it could trigger
-                                    a false flag indicating that the commercials have ended when they have not.
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    If the full channel logo is semi-transparent, it might not work well. Instead, try to select any color that seems to be the most consistent on a graphic over the game.
-                    <ul>
-                        <li>
-                            This is most often some part of the score graphic.
-                        </li>
-                        <li>
-                            Again, prioritize non-black/non-white colors, then white, then black.
-                        </li>
-                        <li>
-                            If you chose this to be your pixel location, make sure to set your "Color Mismatch Count Threshold" in the advanced settings of the extension settings to a higher number
-                            like 20-45, as many networks hide the score graphic while showing replays, and we don't want to accidentally play a YouTube video over top of a replay.
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    If you only have semi-transparent logo/graphic options, select from there
-                    and then crank up the Color Difference Threshold in the settings to 20 or higher to account for different colors showing through the logo/graphic.
-                </li>
-                <li>
-                    If this instruction box is blocking your desired pixel location,
-                    go into the advanced settings of the extension settings and modify the overlay video width, height, and/or X/Y display, as this is where the YouTube video is going to display.
-                </li>
-                <li>
-                    If you would like to change your
-                    pixel selection location at any point, refresh the page and hit the extension keyboard shortcut.
-                </li>
-            </ul>
-        </li>
-        <li>
-            <b>Manual Override</b>: As mentioned above, you can manually override displaying/hiding your YouTube video and temporarily disable the auto commercial detection by hitting the extension keyboard shortcut. You may
-            need to do this semi-often if your pixel selection is inside a score graphic. This extension also has an option for manual mode, where it doesn't try to automatically detect the commercials at all, you will just need to
-            hit the extension keyboard shortcut every time a commercial begins or ends. This mode can be set in the extension settings. Regardless of if using automatic or manual mode, if your computer is hooked up to play through your TV,
-            I highly recommend downloading <i>Touch Portal</i> or <i>Deckboard</i> from the app store on your phone and setting up a shortcut for the extension keyboard shortcut, so you can control this extension on your computer
-            from your phone.
-        </li>
-        <li>
-            <b>Changing YouTube Videos</b>: You can set what YouTube video, playlist, or live video you want to play over top of the commercials by grabbing the video ID or playlist ID from YouTube and plugging it into the
-            extension settings while also selecting the overlay video type. This extension also allows some non-YouTube videos and live streams to play over top of commercials (e.g. playing a different YouTubeTV channel overtop of a YouTubeTV channel's commercials).
-            You can try some out by pasting the full URL of the desired non-YouTube video into the extension settings.
-        </li>
-    </ul>
+    <div id="regular-mode">
+        <h2>Auto Commercial Detection Mode</h2>
+        <p>
+            This mode works by the user (you) selecting a specific pixel on a logo/graphic that only displays when your live game/sport/event/race/program/show is on. Then, the extension continuously checks to
+            see if the pixel selected remains the same color when the logo/graphic is displayed. When the color changes, we know this is most likely due to a commercial because the logo/graphic went away and since
+            commercials are boring, the extension starts playing your YouTube video over top of the commercial. When the logo/graphic color comes back, we know your live program/show/sport/event is most likely back on,
+            so the extension pauses/hides your YouTube video.
+        </p>
+        <h3 style="color: red;">Quick Start Instructions:</h3>
+        <ol>
+            <li>
+                Make sure your live game/program is on (out of commercial).
+                <ol type="i">
+                    <li>
+                        If this isn't going to be anytime soon, refresh the page and hit the extension keyboard shortcut when it is back.
+                    </li>
+                </ol>
+            </li>
+            <li>
+                Click on a pixel outside this box that is within a non-transparent logo or graphic on your game/program (see tips/tricks below for more details).
+                <ol type="i">
+                    <li>
+                        You might need to wait for any video player UI to go away.
+                    </li>
+                    <li>
+                        Refresh the page and then hit the extension keyboard shortcut again if you ever want to chose a different pixel location.
+                    </li>
+                </ol>
+            </li>
+            <li>
+                Let the extension automatically detect the commercials and display your YouTube videos over top of them.
+                <ol type="i">
+                    <li>
+                        You can also manually display/hide your YouTube video, temporarily disabling the auto-detection, at any point by hitting the extension keyboard shortcut.
+                    </li>
+                </ol>
+            </li>
+        </ol>
+        <h3>Tips/Tricks:</h3>
+        <ul>
+            <li>
+                <b>Selecting a Pixel</b>: Automatically detecting commercials across all games/sports/leagues/shows/networks across all streaming platforms isn't an exact science.
+                What will make your experience the best is selecting the best pixel to monitor that you can.
+                <ul>
+                    <li>
+                        You'll want to prioritize selecting a pixel within the channel logo (e.g. the NBC logo) if it is not semi-transparent.
+                        <ul>
+                            <li>
+                                Within the channel logo, you'll want to try to select a color that isn't completely white or completely black (e.g. the blue inside the NBC logo). You'll want to aim for as center mass of the color as possible.
+                                <ul>
+                                    <li>
+                                        If the logo is only black or white, these will do, just prioritize white then black, the only issue you may run into with these are if a commercial has a lot of white or black in them, it could trigger
+                                        a false flag indicating that the commercials have ended when they have not.
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        If the full channel logo is semi-transparent, it might not work well. Instead, try to select any color that seems to be the most consistent on a graphic over the game.
+                        <ul>
+                            <li>
+                                This is most often some part of the score graphic.
+                            </li>
+                            <li>
+                                Again, prioritize non-black/non-white colors, then white, then black.
+                            </li>
+                            <li>
+                                If you chose this to be your pixel location, make sure to set your "Color Mismatch Count Threshold" in the advanced settings of the extension settings to a higher number
+                                like 20-45, as many networks hide the score graphic while showing replays, and we don't want to accidentally play a YouTube video over top of a replay.
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        If you only have semi-transparent logo/graphic options, select from there
+                        and then crank up the Color Difference Threshold in the settings to 20 or higher to account for different colors showing through the logo/graphic.
+                    </li>
+                    <li>
+                        If this instruction box is blocking your desired pixel location,
+                        go into the advanced settings of the extension settings and modify the overlay video width, height, and/or X/Y display, as this is where the YouTube video is going to display.
+                    </li>
+                    <li>
+                        If you would like to change your
+                        pixel selection location at any point, refresh the page and hit the extension keyboard shortcut.
+                    </li>
+                </ul>
+            </li>
+            <li>
+                <b>Manual Override</b>: As mentioned above, you can manually override displaying/hiding your YouTube video and temporarily disable the auto commercial detection by hitting the extension keyboard shortcut. You may
+                need to do this semi-often if your pixel selection is inside a score graphic. This extension also has an option for manual mode, where it doesn't try to automatically detect the commercials at all, you will just need to
+                hit the extension keyboard shortcut every time a commercial begins or ends. This mode can be set in the extension settings. Regardless of if using automatic or manual mode, if your computer is hooked up to play through your TV,
+                I highly recommend downloading <i>Touch Portal</i> or <i>Deckboard</i> from the app store on your phone and setting up a shortcut for the extension keyboard shortcut, so you can control this extension on your computer
+                from your phone.
+            </li>
+            <li>
+                <b>Changing YouTube Videos</b>: You can set what YouTube video, playlist, or live video you want to play over top of the commercials by grabbing the video ID or playlist ID from YouTube and plugging it into the
+                extension settings while also selecting the overlay video type. This extension also allows some non-YouTube videos and live streams to play over top of commercials (e.g. playing a different YouTubeTV channel overtop of a YouTubeTV channel's commercials).
+                You can try some out by pasting the full URL of the desired non-YouTube video into the extension settings.
+            </li>
+        </ul>
+    </div>
+
+    <div id="opposite-mode" style="display: none;">
+        <h2>Auto Commercial Detection Mode [Opposite Mode Enabled]</h2>
+        <p>
+            [Opposite Mode: This mode works great for streams that don't actually show commercials, but instead display some sort of image or looping video while the program is on commercial break. If you do not wish to be in opposite mode, it can be disabled in the advanced settings of the extension.]<br />
+            This mode works by the user (you) selecting a specific pixel on an image that only displays when your live game/sport/event/race/program/show is on commercial break. Then, the extension will play your YouTube video while continuously checking to
+            see if the pixel selected remains the same color. When the color changes, we know this is due the game being back on, so it pauses and hides the YouTube video until the color comes back again.
+        </p>
+        <h3 style="color: red;">Quick Start Instructions:</h3>
+        <ol>
+            <li>
+                Make sure your live game/program is on commercial break.
+                <ol type="i">
+                    <li>
+                        If this isn't going to be anytime soon, refresh the page and hit the extension keyboard shortcut when it is.
+                    </li>
+                </ol>
+            </li>
+            <li>
+                Click on a pixel outside this box that is a consistent color.
+                <ol type="i">
+                    <li>
+                        You might need to wait for any video player UI to go away.
+                    </li>
+                    <li>
+                        Refresh the page and then hit the extension keyboard shortcut again if you ever want to chose a different pixel location.
+                    </li>
+                </ol>
+            </li>
+            <li>
+                Let the extension automatically detect the commercials and display your YouTube videos over top of them.
+                <ol type="i">
+                    <li>
+                        You can also manually display/hide your YouTube video, temporarily disabling the auto-detection, at any point by hitting the extension keyboard shortcut.
+                    </li>
+                </ol>
+            </li>
+        </ol>
+    </div>
+
+    <script src="scripts/instructions.js"></script>
 
 </body>
 </html>

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -165,9 +165,19 @@
             <input type="checkbox" name="shouldClickNextOnPlaySpotify" id="shouldClickNextOnPlaySpotify">
             <label class="checkbox-label" for="shouldClickNextOnPlaySpotify">Auto Next Song</label><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext" style="left: 0px;">For Spotify mode only. Automatically plays the next song when a commercial is detected. Uncheck this if you would like it to resume where a song left of when the last commercial ended.</span></span><br>
 
+            <input type="checkbox" name="isOverlayVideoZoomMode" id="isOverlayVideoZoomMode">
+            <label class="checkbox-label" for="isOverlayVideoZoomMode">Non-YT Video Zoom</label><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext" style="left: 0px;">Trying to play a non YouTube video over commercials and the overlay shows other info on the site besides just the video or some of the video is cut off? Try enabling this setting to fix it!</span></span><br>
+
+            <input type="checkbox" name="isOtherSiteTroubleshootMode" id="isOtherSiteTroubleshootMode">
+            <label class="checkbox-label" for="isOtherSiteTroubleshootMode">Non-YT Video Troubleshoot</label><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Trying to play a non YouTube video over commercials and the video will not mute/unmute or play/pause when it is supposed to? Try enabling this setting to fix it!</span></span><br>
+
+            <input type="checkbox" name="isOppositePixelDetectionMode" id="isOppositePixelDetectionMode">
+            <label class="checkbox-label" for="isOppositePixelDetectionMode">Reverse Pixel Detection Mode</label><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext" style="width: 210px; left: -160px;">Instead of detecting commercial breaks when a pixel is not a specific color, this mode detects the breaks by the pixel being a specific color. This mode works great for streams that don't actually show commercials, but instead display some sort of image or looping video while the program is on commercial break.</span></span><br>
+
             <input type="checkbox" name="isPiPMode" id="isPiPMode">
             <label class="checkbox-label" for="isPiPMode">PiP Mode</label><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext" style="left: 0px;">For YT Live and Non-YT Live Stream modes only. Instead of hiding the overlay video when out of commercial, this sets the video in the corner in a sort of Picture in Picture (PiP) mode.</span></span><br>
             <br>
+
 
             <div class="pip-fields-wrapper">
 
@@ -224,11 +234,11 @@
             <br />
             <br />
 
-            <b>Color Mismatch Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to not match its original color at time of selection before declaring a commercial has begun and playing the video overtop of the commercial.</span></span>
+            <b>Color Mismatch Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to not match its original color at time of selection before declaring a commercial has begun and playing the video overtop of the commercial. NOTE: While in Reverse Pixel Detection Mode, this value is used count matches before declaring commercial break.</span></span>
             <input type="number" name="mismatchCountThreshold" id="mismatchCountThreshold" min="1"><br>
             <br>
 
-            <b>Color Match Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to match its original color at time of selection before declaring the program as resumed and hiding the overlaid video.</span></span>
+            <b>Color Match Count Threshold:</b><span class="tooltip"><sup>&#x1F6C8;</sup><span class="tooltiptext">Number of times in a row the pixel needs to match its original color at time of selection before declaring the program as resumed and hiding the overlaid video. NOTE: While in Reverse Pixel Detection Mode, this value is used count mismatches before declaring being out of commercial break.</span></span>
             <input type="number" name="matchCountThreshold" id="matchCountThreshold" min="1"><br>
             <br>
 

--- a/firefox/scripts/content.js
+++ b/firefox/scripts/content.js
@@ -57,6 +57,7 @@ var pipLocationHorizontal;
 var pipLocationVertical;
 var pipHeight;
 var pipWidth;
+var isOppositePixelDetectionMode;
 //TODO: Add user preference for spotify to have audio come in gradually
 
 
@@ -123,6 +124,11 @@ function addOverlayFade(insertLocation) {
         } else if (selectedPixel) {
 
             overlayScreen.className = "ytoc-overlay-screen-with-hole";
+            if (isFirefox) {
+                //firefox does not need as large of a hole
+                overlayScreen.style.setProperty("width", "6px", "important");
+                overlayScreen.style.setProperty("height", "6px", "important");
+            }
             //setting location of hole for the pixel color detector to look through, subtracting by 3 for radius of hole
             overlayScreen.style.left = (selectedPixel.x - 3) + 'px';
             overlayScreen.style.top = (selectedPixel.y - 3) + 'px';
@@ -403,7 +409,8 @@ chrome.runtime.onMessage.addListener(function (message) {
                             'pipLocationHorizontal',
                             'pipLocationVertical',
                             'pipHeight',
-                            'pipWidth'
+                            'pipWidth',
+                            'isOppositePixelDetectionMode'
                         ], (result) => {
 
                             //set them to default if not set by user yet
@@ -447,13 +454,14 @@ chrome.runtime.onMessage.addListener(function (message) {
                             mismatchCountThreshold = result.mismatchCountThreshold ?? 8;
                             matchCountThreshold = result.matchCountThreshold ?? 2;
                             colorDifferenceMatchingThreshold = result.colorDifferenceMatchingThreshold ?? 12;
-                            manualOverrideCooldown = result.manualOverrideCooldown ?? 30;
+                            manualOverrideCooldown = result.manualOverrideCooldown ?? 55;
                             isDebugMode = result.isDebugMode ?? false;
                             isPiPMode = result.isPiPMode ?? true;
                             pipLocationHorizontal = result.pipLocationHorizontal ?? 'top';
                             pipLocationVertical = result.pipLocationVertical ?? 'left';
                             pipHeight = result.pipHeight ?? 20;
                             pipWidth = result.pipWidth ?? 20;
+                            isOppositePixelDetectionMode = result.isOppositePixelDetectionMode ?? false;
 
                             chrome.runtime.sendMessage({ action: "capture_main_video_tab_id" });
 
@@ -648,7 +656,11 @@ function setBlockersAndPixelSelectionInstructions() {
     }
 
     let iFrame = document.createElement('iframe');
-    iFrame.src = chrome.runtime.getURL('pixel-select-instructions.html');
+    let iFrameSource = chrome.runtime.getURL('pixel-select-instructions.html');
+    if (isOppositePixelDetectionMode) {
+        iFrameSource = iFrameSource + '?opposite_mode=true';
+    }
+    iFrame.src = iFrameSource;
     iFrame.width = "100%";
     iFrame.height = "100%";
     iFrame.allow = "autoplay; encrypted-media";
@@ -776,12 +788,19 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
             let blueDifference = Math.abs(originalPixelColor.b - pixelColor.b);
 
             //TODO: Create HSL option
+            let match;
             if (
                 redDifference > colorDifferenceMatchingThreshold ||
                 greenDifference > colorDifferenceMatchingThreshold ||
                 blueDifference > colorDifferenceMatchingThreshold
             ) {
-                //color mismatch
+                match = false;
+            } else {
+                match = true;
+            }
+
+            if ((!isOppositePixelDetectionMode && !match) || (isOppositePixelDetectionMode && match)) {
+                //color indicating potential commercial break
 
                 mismatchCount++;
                 matchCount = 0;
@@ -819,7 +838,9 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
                         startCommercialMode();
 
                         logoBox.textContent = logoBoxText;
-                        logoBox.style.color = "rgba(" + pixelColor.r + ", " + pixelColor.g + ", " + pixelColor.b + ", 1)";
+                        if (!isOppositePixelDetectionMode) {
+                            logoBox.style.color = "rgba(" + pixelColor.r + ", " + pixelColor.g + ", " + pixelColor.b + ", 1)";
+                        }
                         logoBox.style.display = 'block';
                         if (!isDebugMode && !isAudioOnlyOverlay) {
 
@@ -839,7 +860,7 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
                 }
 
             } else {
-                //color match
+                //color indicating potentially out of commercial break
 
                 matchCount++;
                 mismatchCount = 0;
@@ -878,7 +899,9 @@ function pixelColorMatchMonitor(originalPixelColor, selectedPixel) {
 
             }
 
-            logoBox.style.color = "rgba(" + pixelColor.r + ", " + pixelColor.g + ", " + pixelColor.b + ", 1)";
+            if (!isOppositePixelDetectionMode) {
+                logoBox.style.color = "rgba(" + pixelColor.r + ", " + pixelColor.g + ", " + pixelColor.b + ", 1)";
+            }
 
             cooldownCountRemaining--;
 
@@ -1147,6 +1170,11 @@ function indicateSelectedPixel(selectedPixel) {
     let selectedPixelRing = document.createElement('div');
 
     selectedPixelRing.className = "ytoc-selection-indicator";
+    if (isFirefox) {
+        //firefox does not need as large of a hole
+        selectedPixelRing.style.setProperty("width", "6px", "important");
+        selectedPixelRing.style.setProperty("height", "6px", "important");
+    }
     //setting location of hole for the pixel color detector to look through, subtracting by 3 for radius of hole
     selectedPixelRing.style.left = (selectedPixel.x - 3) + 'px';
     selectedPixelRing.style.top = (selectedPixel.y - 3) + 'px';

--- a/firefox/scripts/instructions.js
+++ b/firefox/scripts/instructions.js
@@ -1,0 +1,13 @@
+
+
+const urlParameters = new URLSearchParams(window.location.search);
+const oppositeMode = urlParameters.get('opposite_mode');
+
+if (oppositeMode) {
+
+    let regularModeElms = document.getElementById('regular-mode');
+    regularModeElms.style.display = 'none';
+    let oppositeModeElms = document.getElementById('opposite-mode');
+    oppositeModeElms.style.display = 'block';
+
+}

--- a/firefox/scripts/popup.js
+++ b/firefox/scripts/popup.js
@@ -29,7 +29,10 @@ chrome.storage.sync.get([
     'pipLocationVertical',
     'pipHeight',
     'pipWidth',
-    'shouldClickNextOnPlaySpotify'
+    'shouldClickNextOnPlaySpotify',
+    'isOverlayVideoZoomMode',
+    'isOtherSiteTroubleshootMode',
+    'isOppositePixelDetectionMode'
 ], (result) => {
 
     //set them to default if not set by user yet
@@ -51,7 +54,7 @@ chrome.storage.sync.get([
     optionsForm.mismatchCountThreshold.value = result.mismatchCountThreshold ?? 8;
     optionsForm.matchCountThreshold.value = result.matchCountThreshold ?? 2;
     optionsForm.colorDifferenceMatchingThreshold.value = result.colorDifferenceMatchingThreshold ?? 12;
-    optionsForm.manualOverrideCooldown.value = result.manualOverrideCooldown ?? 30;
+    optionsForm.manualOverrideCooldown.value = result.manualOverrideCooldown ?? 55;
     optionsForm.isDebugMode.checked = result.isDebugMode ?? false;
     optionsForm.isPiPMode.checked = result.isPiPMode ?? true;
     optionsForm.pipLocationHorizontal.value = result.pipLocationHorizontal ?? 'left';
@@ -59,6 +62,9 @@ chrome.storage.sync.get([
     optionsForm.pipHeight.value = result.pipHeight ?? 20;
     optionsForm.pipWidth.value = result.pipWidth ?? 20;
     optionsForm.shouldClickNextOnPlaySpotify.checked = result.shouldClickNextOnPlaySpotify ?? true;
+    optionsForm.isOverlayVideoZoomMode.checked = result.isOverlayVideoZoomMode ?? false;
+    optionsForm.isOtherSiteTroubleshootMode.checked = result.isOtherSiteTroubleshootMode ?? false;
+    optionsForm.isOppositePixelDetectionMode.checked = result.isOppositePixelDetectionMode ?? false;
 
     document.getElementById(optionsForm.commercialDetectionMode.value).style.display = 'block';
     const modeRadios = document.forms["optionsForm"].elements["commercialDetectionMode"];
@@ -146,7 +152,10 @@ document.getElementById("save-button").onclick = function () {
             pipLocationVertical: optionsForm.pipLocationVertical.value,
             pipHeight: optionsForm.pipHeight.value,
             pipWidth: optionsForm.pipWidth.value,
-            shouldClickNextOnPlaySpotify: optionsForm.shouldClickNextOnPlaySpotify.checked
+            shouldClickNextOnPlaySpotify: optionsForm.shouldClickNextOnPlaySpotify.checked,
+            isOverlayVideoZoomMode: optionsForm.isOverlayVideoZoomMode.checked,
+            isOtherSiteTroubleshootMode: optionsForm.isOtherSiteTroubleshootMode.checked,
+            isOppositePixelDetectionMode: optionsForm.isOppositePixelDetectionMode.checked
         }, function () {
 
             //TODO: get these values to update after extension has already been initiated - partially completed with background_update_preferences

--- a/firefox/styles/style.css
+++ b/firefox/styles/style.css
@@ -23,8 +23,8 @@
     border-radius: 50% !important;
     z-index: 2147483646 !important;
     position: absolute !important;
-    width: 6px !important;
-    height: 6px !important;
+    width: 10px !important;
+    height: 10px !important;
     pointer-events: none !important;
 }
 
@@ -77,8 +77,8 @@
     z-index: 2147483646 !important;
     position: absolute !important;
     display: inline-block !important;
-    width: 6px !important;
-    height: 6px !important;
+    width: 10px !important;
+    height: 10px !important;
     border-radius: 50% !important;
     /*border-style: solid !important;
     border-width: 2px !important;


### PR DESCRIPTION
Made changes recently done to chrome:
- Added a reverse pixel detection mode
- Removed the unnecessary tabs permission
- Added troubleshooting options for non-YT overlay videos